### PR TITLE
Turn off codecov commenting

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,1 @@
+comment: false


### PR DESCRIPTION
This turns off codecov commenting in PRs, in favour of the codecov status checks reported alongside the GH actions status.