### PR TITLE
Pin brainglobe-utils version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 dependencies = [
     "brainglobe-atlasapi >=2.0.1",
     "brainglobe-space >=1.0.0",
-    "brainglobe-utils",
+    "brainglobe-utils >=0.4.2",
     "napari",
     "tifffile>=2020.8.13",
     "numpy",


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [X] Other

**Why is this PR needed?**
There is currently no minimum pinned version of `brainglobe-utils`

**What does this PR do?**
Pins the minimum required `brainglobe-utils` version to 0.4.2

## References


## How has this PR been tested?

All tests pass locally.

## Is this a breaking change?

No

## Does this PR require an update to the documentation?

No

## Checklist:

- [X] The code has been tested locally
- [X] Tests have been added to cover all new functionality (unit & integration)
- [X] The documentation has been updated to reflect any changes
- [X] The code has been formatted with [pre-commit](https://pre-commit.com/)
