### PR TITLE
Pins napari

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "brainglobe-atlasapi >=2.0.1",
     "brainglobe-space >=1.0.0",
     "brainglobe-utils >=0.4.2",
-    "napari",
+    "napari<0.6.0",
     "tifffile>=2020.8.13",
     "numpy",
     "pandas",


### PR DESCRIPTION
Pinning napari<0.6.0. Can't instantiate a label layer from an array of uint32 dtype in napari==0.6.0.