### PR TITLE
Exclude napari 0.6.0, pin >= 0.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "brainglobe-atlasapi >=2.0.1",
     "brainglobe-space >=1.0.0",
     "brainglobe-utils >=0.4.2",
-    "napari<0.6.0",
+    "napari >=0.5, !=0.6.0",
     "tifffile>=2020.8.13",
     "numpy",
     "pandas",


### PR DESCRIPTION
Reverting napari pin and standardising minimum napari version across BrainGlobe.