### PR TITLE
Runs scheduled tests again napari main

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -48,6 +48,14 @@ jobs:
           python-version: ${{ matrix.python-version }}
           secret-codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
+      # Run tests on napari main if this is a scheduled run
+      - name: Run tests on napari main
+        if: github.event_name == 'schedule'
+        uses: neuroinformatics-unit/actions/test@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+          secret-codecov-token: ${{ secrets.CODECOV_TOKEN }}
+          tox-args: '-e napari-dev'
 
       - name: Notify slack on scheduled failure
         if: failure() && github.event_name == 'schedule'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,7 @@ fix = true
 [tool.tox]
 legacy_tox_ini = """
 [tox]
-envlist = py{311,312,313}
+envlist = py{310,311,312}, napari-dev
 isolated_build = True
 
 [gh-actions]
@@ -108,4 +108,6 @@ extras =
     dev
 commands =
     pytest -v --color=yes --cov=brainglobe_napari_io --cov-report=xml
+deps =
+    napari-dev: git+https://github.com/napari/napari
 """


### PR DESCRIPTION
Adds an extra run of the neuroinformatics/actions/test with napari installed from main. This action will only run during the weekly cron job.