### PR TITLE
Add support for yaml files and metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ This is typically only used in other software, but you can enable it yourself:
 
 
 ### cellfinder
-#### Load cellfinder XML file
+#### Load cellfinder XML/YAML file
 * Load your raw data (drag and drop the data directories into napari, one at a time)
-* Drag and drop your cellfinder XML file (e.g. `cell_classification.xml`) into napari.
+* Drag and drop your cellfinder XML/YAML file (e.g. `cell_classification.xml`) into napari.
 
 #### Load cellfinder directory
 * Load your raw data (drag and drop the data directories into napari, one at a time)

--- a/brainglobe_napari_io/cellfinder/reader_points.py
+++ b/brainglobe_napari_io/cellfinder/reader_points.py
@@ -1,10 +1,11 @@
 from pathlib import Path
-from xml.etree import ElementTree
+
+from brainglobe_utils.IO.cells import is_brainglobe_xml, is_brainglobe_yaml
 
 from .utils import load_cells
 
 
-def cellfinder_read_xml(path):
+def cellfinder_read_points(path):
     """A basic implementation of the napari_get_reader hook specification.
 
     Parameters
@@ -18,27 +19,28 @@ def cellfinder_read_xml(path):
         If the path is a recognized format, return a function that accepts the
         same path or list of paths, and returns a list of layer data tuples.
     """
-    if isinstance(path, str) and is_cellfinder_xml(path):
-        return xml_reader
+    if isinstance(path, str) and (
+        is_cellfinder_xml(path) or is_cellfinder_yaml(path)
+    ):
+        return points_reader
+    return None
 
 
 def is_cellfinder_xml(path):
     path = Path(path).resolve()
     if path.suffix == ".xml":
-        try:
-            with open(path, "r") as xml_file:
-                root = ElementTree.parse(xml_file).getroot()
-                if root.tag == "CellCounter_Marker_File":
-                    return True
-                else:
-                    return False
-        except Exception:
-            return False
-    else:
-        return False
+        return is_brainglobe_xml(path)
+    return False
 
 
-def xml_reader(path, point_size=15, opacity=0.6, symbol="ring"):
+def is_cellfinder_yaml(path):
+    path = Path(path).resolve()
+    if path.suffix in (".yaml", ".yml"):
+        return is_brainglobe_yaml(path)
+    return False
+
+
+def points_reader(path, point_size=15, opacity=0.6, symbol="ring"):
     """Take a path or list of paths and return a list of LayerData tuples.
 
     Readers are expected to return data as a list of tuples, where each tuple
@@ -62,7 +64,7 @@ def xml_reader(path, point_size=15, opacity=0.6, symbol="ring"):
         layer_type=="image" if not provided
     """
     path = Path(path).resolve()
-    print("Loading cellfinder XML file")
+    print("Loading cellfinder XML/YAML points file")
 
     layers = []
     layers = load_cells(

--- a/brainglobe_napari_io/cellfinder/reader_points.py
+++ b/brainglobe_napari_io/cellfinder/reader_points.py
@@ -20,7 +20,7 @@ def cellfinder_read_points(path):
         same path or list of paths, and returns a list of layer data tuples.
     """
     if isinstance(path, str) and (
-        is_cellfinder_xml(path) or is_cellfinder_yaml(path)
+        is_cellfinder_xml(path) or is_cellfinder_yml(path)
     ):
         return points_reader
     return None
@@ -33,7 +33,7 @@ def is_cellfinder_xml(path):
     return False
 
 
-def is_cellfinder_yaml(path):
+def is_cellfinder_yml(path):
     path = Path(path).resolve()
     if path.suffix in (".yaml", ".yml"):
         return is_brainglobe_yaml(path)

--- a/brainglobe_napari_io/cellfinder/utils.py
+++ b/brainglobe_napari_io/cellfinder/utils.py
@@ -1,14 +1,50 @@
+from collections import defaultdict
+from functools import partial
 from pathlib import Path
+from typing import Any
 
 import numpy as np
-import pandas as pd
 from brainglobe_utils.cells.cells import Cell
 from brainglobe_utils.IO.cells import get_cells
 from napari.types import LayerDataTuple
 
+# empty value we use to indicate metadata item that was not present for a cell
+EMPTY_VALUE = object()
 
-def _cells_metadata_to_df(cells: list[Cell], type: int) -> pd.DataFrame:
-    return pd.DataFrame([c.metadata for c in cells if c.type == type])
+
+def empty_object_array(n):
+    """Returns an array of the given size filled with the empty sentinel."""
+    return np.full(n, EMPTY_VALUE, dtype=object)
+
+
+def cells_metadata_to_arrays(
+    cells: list[Cell], type: int
+) -> tuple[dict[Any, np.ndarray], dict[Any, object]]:
+    """
+    Given a list of cells, after filtering out any cells not of the `type`, it
+    returns a dictionary representing all the metadata of all the cells. This
+    can be passed to napari as features of the point layer.
+
+    The dictionary's keys are the union of all the keys of the metadata of all
+    the cells. Their values are each a np object array filled with the empty
+    sentinel, except for those cells who have values for the given key.
+
+    Napari will track this in the points layer, adjusting the size of the
+    arrays when new points are added/removed in the GUI. Via feature_defaults,
+    napari sets new points values to the sentinel value.
+    """
+    cells = [c for c in cells if c.type == type]
+
+    # any new metadata key we encounter, if we haven't seen it, we create an
+    # empty array filled with the sentinel. Only those cells who have values
+    # for a given key have a non-sentinel value
+    data: dict = defaultdict(partial(empty_object_array, len(cells)))
+    for i, cell in enumerate(cells):
+        for key, value in cell.metadata.items():
+            data[key][i] = value
+
+    defaults = {key: EMPTY_VALUE for key in data.keys()}
+    return data, defaults
 
 
 def get_cell_arrays(all_cells: list[Cell]) -> tuple[np.ndarray, np.ndarray]:
@@ -20,15 +56,26 @@ def get_cell_arrays(all_cells: list[Cell]) -> tuple[np.ndarray, np.ndarray]:
     cells = [c for c in all_cells if c.type == Cell.CELL]
 
     # napari expect z, y, x order
-    non_cells_pos = np.array([(c.z, c.y, c.z) for c in non_cells])
-    cells_pos = np.array([(c.z, c.y, c.z) for c in cells])
+    non_cells_pos = np.array([(c.z, c.y, c.x) for c in non_cells])
+    cells_pos = np.array([(c.z, c.y, c.x) for c in cells])
 
     return cells_pos, non_cells_pos
 
 
 def convert_layer_to_cells(
-    layer_data, cells: bool = True, features: pd.DataFrame | None = None
+    layer_data,
+    cells: bool = True,
+    features: dict[Any, np.ndarray] | None = None,
 ) -> list[Cell]:
+    """
+    Gets the cells from the layer.
+
+    :param layer_data: the points from the layer.
+    :param cells: Whether to mark the cells as a Cell or Unknown.
+    :param features: The napari tracked features dict that stores the cell
+        metadata.
+    :return: The list of cells.
+    """
     cells_to_save = []
     if cells:
         cell_type = Cell.CELL
@@ -37,11 +84,20 @@ def convert_layer_to_cells(
 
     for idx, point in enumerate(layer_data):
         metadata = {}
+        # if we have features/metadata, get the keys whose values are not
+        # the empty sentinel. Features has the union of metadata keys of all
+        # the cells. We want only keys that was provided for this cell.
+        # When creating new points in the GUI, via feature_defaults, napari
+        # initialize their metadata to the empty sentinel
         if features is not None:
-            metadata = features.iloc[idx].to_dict()
+            for name, arr in features.items():
+                if arr[idx] is not EMPTY_VALUE:
+                    metadata[name] = arr[idx]
 
         cell = Cell(
-            [point[2], point[1], point[0]], cell_type, metadata=metadata
+            [point[2], point[1], point[0]],
+            cell_type,
+            metadata=metadata,
         )
         cells_to_save.append(cell)
 
@@ -60,9 +116,14 @@ def load_cells(
 ) -> list[LayerDataTuple]:
     all_cells = get_cells(str(classified_cells_path), cells_only=False)
     cells, non_cells = get_cell_arrays(all_cells)
-    # napari accepts arbitrary features as a data frame
-    cells_metadata = _cells_metadata_to_df(all_cells, Cell.CELL)
-    non_cells_metadata = _cells_metadata_to_df(all_cells, Cell.UNKNOWN)
+    # napari accepts arbitrary features as a dict of arrays, we use that for
+    # letting napari track the metadata of the cells
+    cells_metadata, cells_metadata_defaults = cells_metadata_to_arrays(
+        all_cells, Cell.CELL
+    )
+    non_cells_metadata, non_cells_metadata_defaults = cells_metadata_to_arrays(
+        all_cells, Cell.UNKNOWN
+    )
 
     if channel is not None:
         channel_base = f"channel_{channel}: "
@@ -74,6 +135,7 @@ def load_cells(
             non_cells,
             {
                 "features": non_cells_metadata,
+                "feature_defaults": non_cells_metadata_defaults,
                 "name": channel_base + "Non cells",
                 "size": point_size,
                 "n_dimensional": True,
@@ -90,6 +152,7 @@ def load_cells(
             cells,
             {
                 "features": cells_metadata,
+                "feature_defaults": cells_metadata_defaults,
                 "name": channel_base + "Cells",
                 "size": point_size,
                 "n_dimensional": True,

--- a/brainglobe_napari_io/cellfinder/utils.py
+++ b/brainglobe_napari_io/cellfinder/utils.py
@@ -1,42 +1,34 @@
 from pathlib import Path
-from typing import List, Tuple
 
 import numpy as np
 import pandas as pd
 from brainglobe_utils.cells.cells import Cell
-from brainglobe_utils.IO.cells import cells_to_dataframe, get_cells
+from brainglobe_utils.IO.cells import get_cells
 from napari.types import LayerDataTuple
 
 
-def cells_df_as_np(
-    cells_df: pd.DataFrame,
-    new_order: List[int] = [2, 1, 0],
-    type_column: str = "type",
-) -> np.ndarray:
-    cells_df = cells_df.drop(columns=[type_column])
-    cells = cells_df[cells_df.columns[new_order]]
-    cells = cells.to_numpy()
-    return cells
-
-
-def cells_metadata_to_df(cells: list[Cell], type: int) -> pd.DataFrame:
+def _cells_metadata_to_df(cells: list[Cell], type: int) -> pd.DataFrame:
     return pd.DataFrame([c.metadata for c in cells if c.type == type])
 
 
-def get_cell_arrays(all_cells: list[Cell]) -> Tuple[np.ndarray, np.ndarray]:
-    df = cells_to_dataframe(all_cells)
+def get_cell_arrays(all_cells: list[Cell]) -> tuple[np.ndarray, np.ndarray]:
+    """
+    Returns two Nx3 and Mx3 arrays with the z,y,x position of the cells that
+    are "UNKNOWN", and "CELL", respectively.
+    """
+    non_cells = [c for c in all_cells if c.type == Cell.UNKNOWN]
+    cells = [c for c in all_cells if c.type == Cell.CELL]
 
-    non_cells = df[df["type"] == Cell.UNKNOWN]
-    cells = df[df["type"] == Cell.CELL]
+    # napari expect z, y, x order
+    non_cells_pos = np.array([(c.z, c.y, c.z) for c in non_cells])
+    cells_pos = np.array([(c.z, c.y, c.z) for c in cells])
 
-    cells = cells_df_as_np(cells)
-    non_cells = cells_df_as_np(non_cells)
-    return cells, non_cells
+    return cells_pos, non_cells_pos
 
 
 def convert_layer_to_cells(
     layer_data, cells: bool = True, features: pd.DataFrame | None = None
-) -> List[Cell]:
+) -> list[Cell]:
     cells_to_save = []
     if cells:
         cell_type = Cell.CELL
@@ -57,7 +49,7 @@ def convert_layer_to_cells(
 
 
 def load_cells(
-    layers: List[LayerDataTuple],
+    layers: list[LayerDataTuple],
     classified_cells_path: Path,
     point_size: int,
     opacity: float,
@@ -65,11 +57,12 @@ def load_cells(
     cell_color: str,
     non_cell_color: str,
     channel=None,
-) -> List[LayerDataTuple]:
+) -> list[LayerDataTuple]:
     all_cells = get_cells(str(classified_cells_path), cells_only=False)
     cells, non_cells = get_cell_arrays(all_cells)
-    cells_metadata = cells_metadata_to_df(all_cells, Cell.CELL)
-    non_cells_metadata = cells_metadata_to_df(all_cells, Cell.UNKNOWN)
+    # napari accepts arbitrary features as a data frame
+    cells_metadata = _cells_metadata_to_df(all_cells, Cell.CELL)
+    non_cells_metadata = _cells_metadata_to_df(all_cells, Cell.UNKNOWN)
 
     if channel is not None:
         channel_base = f"channel_{channel}: "

--- a/brainglobe_napari_io/cellfinder/writer_points.py
+++ b/brainglobe_napari_io/cellfinder/writer_points.py
@@ -8,7 +8,7 @@ from napari.utils.notifications import show_info
 from .utils import convert_layer_to_cells
 
 
-def write_multiple_points_to_xml(
+def write_multiple_points(
     path: str, layer_data: List[FullLayerData]
 ) -> List[str]:
     cells_to_save = []
@@ -21,11 +21,23 @@ def write_multiple_points_to_xml(
                 f'Did not find point type in metadata for "{name}" layer, '
                 "Defaulting to 'Unknown'"
             )
-            cells_to_save.extend(convert_layer_to_cells(data, cells=False))
+            cells_to_save.extend(
+                convert_layer_to_cells(
+                    data, cells=False, features=attributes.get("features")
+                )
+            )
         elif attributes["metadata"]["point_type"] == Cell.CELL:
-            cells_to_save.extend(convert_layer_to_cells(data))
+            cells_to_save.extend(
+                convert_layer_to_cells(
+                    data, features=attributes.get("features")
+                )
+            )
         elif attributes["metadata"]["point_type"] == Cell.UNKNOWN:
-            cells_to_save.extend(convert_layer_to_cells(data, cells=False))
+            cells_to_save.extend(
+                convert_layer_to_cells(
+                    data, cells=False, features=attributes.get("features")
+                )
+            )
 
     if cells_to_save:
         save_cells(cells_to_save, path)

--- a/brainglobe_napari_io/napari.yaml
+++ b/brainglobe_napari_io/napari.yaml
@@ -14,13 +14,17 @@ contributions:
     title: Brainmapper Read Directory
     python_name: brainglobe_napari_io.brainmapper.brainmapper_reader_dir:brainmapper_read_dir
 
-  - id: brainglobe-napari-io.cellfinder_read_xml
+  - id: brainglobe-napari-io.cellfinder_read_points
     title: Cellfinder Read XML
-    python_name: brainglobe_napari_io.cellfinder.reader_xml:cellfinder_read_xml
+    python_name: brainglobe_napari_io.cellfinder.reader_points:cellfinder_read_points
 
-  - id: brainglobe-napari-io.cellfinder_write_multiple_xml
-    title: Write Points
-    python_name: brainglobe_napari_io.cellfinder.writer_xml:write_multiple_points_to_xml
+  - id: brainglobe-napari-io.cellfinder_read_yml
+    title: Cellfinder Read YAML
+    python_name: brainglobe_napari_io.cellfinder.reader_yml:cellfinder_read_yml
+
+  - id: brainglobe-napari-io.cellfinder_write_multiple_points
+    title: Write Points to XML/YAML
+    python_name: brainglobe_napari_io.cellfinder.writer_points:write_multiple_points
 
 
   readers:
@@ -39,16 +43,20 @@ contributions:
     - '*.tif'
     accepts_directories: true
 
-  - command: brainglobe-napari-io.cellfinder_read_xml
+  - command: brainglobe-napari-io.cellfinder_read_points
     filename_patterns:
     - '*.xml'
+    - '*.yml'
+    - '*.yaml'
     accepts_directories: false
 
 
   writers:
-  - command: brainglobe-napari-io.cellfinder_write_multiple_xml
+  - command: brainglobe-napari-io.cellfinder_write_multiple_points
     layer_types:
     - "points+"
     filename_extensions:
       - .xml
+      - .yml
+      - .yaml
     display_name: multiple_points

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ dependencies = [
     "napari >=0.5, !=0.6.0",
     "tifffile>=2020.8.13",
     "numpy",
-    "pandas",
 ]
 
 [project.urls]

--- a/tests/data/yml/cell_classification.yml
+++ b/tests/data/yml/cell_classification.yml
@@ -1,0 +1,632 @@
+brainglobe_utils_version: 0.1.dev332+gd8a1722.d20250624
+CellCounter_Marker_File: true
+num_candidates: 125
+candidate_cells:
+  - x: 3422
+    y: 2089
+    z: 11
+    type: 1
+    metadata:
+      Hello: Cell
+  - x: 3407
+    y: 2580
+    z: 11
+    type: 1
+    metadata: {}
+  - x: 1229
+    y: 2570
+    z: 11
+    type: 1
+    metadata: {}
+  - x: 1265
+    y: 1055
+    z: 11
+    type: 1
+    metadata: {}
+  - x: 942
+    y: 1133
+    z: 11
+    type: 1
+    metadata: {}
+  - x: 901
+    y: 1235
+    z: 11
+    type: 1
+    metadata: {}
+  - x: 2771
+    y: 1245
+    z: 11
+    type: 1
+    metadata: {}
+  - x: 2194
+    y: 1252
+    z: 11
+    type: 1
+    metadata: {}
+  - x: 1351
+    y: 1259
+    z: 11
+    type: 1
+    metadata: {}
+  - x: 1715
+    y: 1324
+    z: 11
+    type: 1
+    metadata: {}
+  - x: 2842
+    y: 1341
+    z: 11
+    type: 1
+    metadata: {}
+  - x: 1533
+    y: 1372
+    z: 11
+    type: 1
+    metadata: {}
+  - x: 1336
+    y: 2135
+    z: 2540
+    type: 1
+    metadata: {}
+  - x: 1336
+    y: 3066
+    z: 2540
+    type: 1
+    metadata: {}
+  - x: 1280
+    y: 3221
+    z: 2540
+    type: 1
+    metadata: {}
+  - x: 1556
+    y: 2034
+    z: 2540
+    type: 1
+    metadata: {}
+  - x: 1121
+    y: 2114
+    z: 2540
+    type: 1
+    metadata: {}
+  - x: 2028
+    y: 2137
+    z: 2540
+    type: 1
+    metadata: {}
+  - x: 1923
+    y: 2386
+    z: 2540
+    type: 1
+    metadata: {}
+  - x: 2057
+    y: 2731
+    z: 2540
+    type: 1
+    metadata: {}
+  - x: 1860
+    y: 2739
+    z: 2540
+    type: 1
+    metadata: {}
+  - x: 1399
+    y: 3301
+    z: 2540
+    type: 1
+    metadata: {}
+  - x: 1674
+    y: 2441
+    z: 20
+    type: 2
+    metadata: {}
+  - x: 2194
+    y: 2810
+    z: 120
+    type: 2
+    metadata: {}
+  - x: 1634
+    y: 1891
+    z: 122
+    type: 2
+    metadata: {}
+  - x: 3363
+    y: 2528
+    z: 183
+    type: 2
+    metadata: {}
+  - x: 2158
+    y: 2763
+    z: 187
+    type: 2
+    metadata: {}
+  - x: 1661
+    y: 3150
+    z: 200
+    type: 2
+    metadata: {}
+  - x: 2393
+    y: 1830
+    z: 224
+    type: 2
+    metadata: {}
+  - x: 1236
+    y: 2647
+    z: 238
+    type: 2
+    metadata: {}
+  - x: 1833
+    y: 2733
+    z: 314
+    type: 2
+    metadata: {}
+  - x: 2012
+    y: 1735
+    z: 315
+    type: 2
+    metadata: {}
+  - x: 2520
+    y: 3135
+    z: 318
+    type: 2
+    metadata: {}
+  - x: 2479
+    y: 2402
+    z: 333
+    type: 2
+    metadata: {}
+  - x: 977
+    y: 3615
+    z: 339
+    type: 2
+    metadata: {}
+  - x: 985
+    y: 3616
+    z: 339
+    type: 2
+    metadata: {}
+  - x: 1323
+    y: 3061
+    z: 368
+    type: 2
+    metadata: {}
+  - x: 616
+    y: 1843
+    z: 388
+    type: 2
+    metadata: {}
+  - x: 1252
+    y: 3608
+    z: 408
+    type: 2
+    metadata: {}
+  - x: 1242
+    y: 3608
+    z: 411
+    type: 2
+    metadata: {}
+  - x: 1343
+    y: 3908
+    z: 419
+    type: 2
+    metadata: {}
+  - x: 1273
+    y: 3639
+    z: 419
+    type: 2
+    metadata: {}
+  - x: 1421
+    y: 3977
+    z: 417
+    type: 2
+    metadata: {}
+  - x: 1361
+    y: 3927
+    z: 417
+    type: 2
+    metadata: {}
+  - x: 1358
+    y: 3930
+    z: 421
+    type: 2
+    metadata: {}
+  - x: 1417
+    y: 3980
+    z: 421
+    type: 2
+    metadata: {}
+  - x: 1211
+    y: 3800
+    z: 422
+    type: 2
+    metadata: {}
+  - x: 1263
+    y: 3814
+    z: 422
+    type: 2
+    metadata: {}
+  - x: 1330
+    y: 3749
+    z: 425
+    type: 2
+    metadata: {}
+  - x: 1348
+    y: 3871
+    z: 427
+    type: 2
+    metadata: {}
+  - x: 1385
+    y: 3982
+    z: 431
+    type: 2
+    metadata: {}
+  - x: 3360
+    y: 2122
+    z: 434
+    type: 2
+    metadata: {}
+  - x: 1548
+    y: 4018
+    z: 433
+    type: 2
+    metadata: {}
+  - x: 1049
+    y: 3573
+    z: 435
+    type: 2
+    metadata: {}
+  - x: 1385
+    y: 3908
+    z: 435
+    type: 2
+    metadata: {}
+  - x: 1437
+    y: 3966
+    z: 435
+    type: 2
+    metadata: {}
+  - x: 1468
+    y: 3960
+    z: 436
+    type: 2
+    metadata: {}
+  - x: 2081
+    y: 4073
+    z: 439
+    type: 2
+    metadata: {}
+  - x: 1524
+    y: 3970
+    z: 441
+    type: 2
+    metadata: {}
+  - x: 1415
+    y: 4013
+    z: 441
+    type: 2
+    metadata: {}
+  - x: 1354
+    y: 3769
+    z: 438
+    type: 2
+    metadata: {}
+  - x: 1418
+    y: 4012
+    z: 438
+    type: 2
+    metadata: {}
+  - x: 3367
+    y: 2125
+    z: 438
+    type: 2
+    metadata: {}
+  - x: 1478
+    y: 3891
+    z: 440
+    type: 2
+    metadata: {}
+  - x: 2127
+    y: 4025
+    z: 442
+    type: 2
+    metadata: {}
+  - x: 1244
+    y: 3898
+    z: 443
+    type: 2
+    metadata: {}
+  - x: 1478
+    y: 4015
+    z: 446
+    type: 2
+    metadata: {}
+  - x: 1393
+    y: 3717
+    z: 446
+    type: 2
+    metadata: {}
+  - x: 1468
+    y: 3950
+    z: 446
+    type: 2
+    metadata: {}
+  - x: 1468
+    y: 3948
+    z: 447
+    type: 2
+    metadata: {}
+  - x: 1239
+    y: 3488
+    z: 445
+    type: 2
+    metadata: {}
+  - x: 1486
+    y: 3986
+    z: 448
+    type: 2
+    metadata: {}
+  - x: 1417
+    y: 3697
+    z: 449
+    type: 2
+    metadata: {}
+  - x: 1382
+    y: 3941
+    z: 449
+    type: 2
+    metadata: {}
+  - x: 1433
+    y: 3807
+    z: 451
+    type: 2
+    metadata: {}
+  - x: 1416
+    y: 3887
+    z: 451
+    type: 2
+    metadata: {}
+  - x: 1379
+    y: 3944
+    z: 452
+    type: 2
+    metadata: {}
+  - x: 1460
+    y: 3894
+    z: 453
+    type: 2
+    metadata: {}
+  - x: 1461
+    y: 3793
+    z: 453
+    type: 2
+    metadata: {}
+  - x: 1520
+    y: 3957
+    z: 455
+    type: 2
+    metadata: {}
+  - x: 998
+    y: 3647
+    z: 455
+    type: 2
+    metadata: {}
+  - x: 1417
+    y: 3708
+    z: 460
+    type: 2
+    metadata: {}
+  - x: 1468
+    y: 3944
+    z: 459
+    type: 2
+    metadata: {}
+  - x: 1432
+    y: 3803
+    z: 457
+    type: 2
+    metadata: {}
+  - x: 1526
+    y: 4033
+    z: 456
+    type: 2
+    metadata: {}
+  - x: 1040
+    y: 3718
+    z: 458
+    type: 2
+    metadata: {}
+  - x: 1438
+    y: 3688
+    z: 458
+    type: 2
+    metadata: {}
+  - x: 1432
+    y: 3802
+    z: 458
+    type: 2
+    metadata: {}
+  - x: 1458
+    y: 3884
+    z: 464
+    type: 2
+    metadata: {}
+  - x: 1581
+    y: 4079
+    z: 464
+    type: 2
+    metadata: {}
+  - x: 1408
+    y: 3735
+    z: 465
+    type: 2
+    metadata: {}
+  - x: 1442
+    y: 3686
+    z: 465
+    type: 2
+    metadata: {}
+  - x: 1043
+    y: 3745
+    z: 465
+    type: 2
+    metadata: {}
+  - x: 1435
+    y: 3853
+    z: 465
+    type: 2
+    metadata: {}
+  - x: 1435
+    y: 3682
+    z: 465
+    type: 2
+    metadata: {}
+  - x: 1134
+    y: 3455
+    z: 466
+    type: 2
+    metadata: {}
+  - x: 1742
+    y: 4005
+    z: 467
+    type: 2
+    metadata: {}
+  - x: 1005
+    y: 3697
+    z: 467
+    type: 2
+    metadata: {}
+  - x: 1395
+    y: 3693
+    z: 467
+    type: 2
+    metadata: {}
+  - x: 2269
+    y: 4185
+    z: 467
+    type: 2
+    metadata: {}
+  - x: 1392
+    y: 3695
+    z: 470
+    type: 2
+    metadata: {}
+  - x: 1579
+    y: 3983
+    z: 469
+    type: 2
+    metadata: {}
+  - x: 1572
+    y: 3974
+    z: 473
+    type: 2
+    metadata: {}
+  - x: 1123
+    y: 3423
+    z: 471
+    type: 2
+    metadata: {}
+  - x: 2243
+    y: 3863
+    z: 474
+    type: 2
+    metadata: {}
+  - x: 1420
+    y: 3713
+    z: 475
+    type: 2
+    metadata: {}
+  - x: 1198
+    y: 3691
+    z: 475
+    type: 2
+    metadata: {}
+  - x: 1530
+    y: 3751
+    z: 475
+    type: 2
+    metadata: {}
+  - x: 2518
+    y: 4054
+    z: 477
+    type: 2
+    metadata: {}
+  - x: 1406
+    y: 3754
+    z: 479
+    type: 2
+    metadata: {}
+  - x: 1109
+    y: 3806
+    z: 479
+    type: 2
+    metadata: {}
+  - x: 1154
+    y: 3637
+    z: 482
+    type: 2
+    metadata: {}
+  - x: 1438
+    y: 3725
+    z: 482
+    type: 2
+    metadata: {}
+  - x: 1584
+    y: 3983
+    z: 485
+    type: 2
+    metadata: {}
+  - x: 636
+    y: 2486
+    z: 484
+    type: 2
+    metadata: {}
+  - x: 1346
+    y: 3539
+    z: 486
+    type: 2
+    metadata: {}
+  - x: 670
+    y: 2735
+    z: 486
+    type: 2
+    metadata: {}
+  - x: 1593
+    y: 4069
+    z: 488
+    type: 2
+    metadata: {}
+  - x: 1484
+    y: 3983
+    z: 489
+    type: 2
+    metadata: {}
+  - x: 897
+    y: 3542
+    z: 490
+    type: 2
+    metadata: {}
+  - x: 1505
+    y: 3676
+    z: 490
+    type: 2
+    metadata: {}
+  - x: 1437
+    y: 3635
+    z: 492
+    type: 2
+    metadata: {}
+  - x: 904
+    y: 1256
+    z: 493
+    type: 2
+    metadata: {}
+  - x: 887
+    y: 3337
+    z: 493
+    type: 2
+    metadata: {}
+  - x: 1996
+    y: 3220
+    z: 2529
+    type: 2
+    metadata:
+      Hello: Point
+      Bye: 42

--- a/tests/tests/test_integration/test_cellfinder_reader.py
+++ b/tests/tests/test_integration/test_cellfinder_reader.py
@@ -2,7 +2,7 @@ import pathlib
 
 import numpy as np
 
-from brainglobe_napari_io.cellfinder import reader_xml
+from brainglobe_napari_io.cellfinder import reader_points
 
 xml_dir = pathlib.Path(__file__).parent.parent.parent / "data" / "xml"
 xml_file = xml_dir / "cell_classification.xml"
@@ -11,15 +11,18 @@ xml_with_incorrect_root_tag = xml_dir / "incorrect_tag.xml"
 
 
 def test_is_cellfinder_xml():
-    assert reader_xml.is_cellfinder_xml(xml_file)
-    assert not reader_xml.is_cellfinder_xml(__file__)
-    assert not reader_xml.is_cellfinder_xml(broken_xml)
-    assert not reader_xml.is_cellfinder_xml(xml_with_incorrect_root_tag)
+    assert reader_points.is_cellfinder_xml(xml_file)
+    assert not reader_points.is_cellfinder_xml(__file__)
+    assert not reader_points.is_cellfinder_xml(broken_xml)
+    assert not reader_points.is_cellfinder_xml(xml_with_incorrect_root_tag)
 
 
 def test_reader_xml():
-    assert reader_xml.cellfinder_read_xml(str(xml_file.resolve())) is not None
-    layers = reader_xml.xml_reader(xml_file)
+    assert (
+        reader_points.cellfinder_read_points(str(xml_file.resolve()))
+        is not None
+    )
+    layers = reader_points.points_reader(xml_file)
 
     assert len(layers) == 2
 

--- a/tests/tests/test_integration/test_cellfinder_reader.py
+++ b/tests/tests/test_integration/test_cellfinder_reader.py
@@ -1,28 +1,40 @@
 import pathlib
 
 import numpy as np
+import pytest
 
 from brainglobe_napari_io.cellfinder import reader_points
 
-xml_dir = pathlib.Path(__file__).parent.parent.parent / "data" / "xml"
+data_root = pathlib.Path(__file__).parent.parent.parent / "data"
+xml_dir = data_root / "xml"
+yml_dir = data_root / "yml"
 xml_file = xml_dir / "cell_classification.xml"
+yml_file = yml_dir / "cell_classification.yml"
 broken_xml = xml_dir / "broken_xml.xml"
 xml_with_incorrect_root_tag = xml_dir / "incorrect_tag.xml"
 
 
 def test_is_cellfinder_xml():
     assert reader_points.is_cellfinder_xml(xml_file)
+    assert not reader_points.is_cellfinder_xml(yml_file)
     assert not reader_points.is_cellfinder_xml(__file__)
     assert not reader_points.is_cellfinder_xml(broken_xml)
     assert not reader_points.is_cellfinder_xml(xml_with_incorrect_root_tag)
 
 
-def test_reader_xml():
+def test_is_cellfinder_yml():
+    assert reader_points.is_cellfinder_yml(yml_file)
+    assert not reader_points.is_cellfinder_yml(xml_file)
+    assert not reader_points.is_cellfinder_yml(__file__)
+
+
+@pytest.mark.parametrize("filename", [xml_file, yml_file])
+def test_reader_xml(filename):
     assert (
-        reader_points.cellfinder_read_points(str(xml_file.resolve()))
+        reader_points.cellfinder_read_points(str(filename.resolve()))
         is not None
     )
-    layers = reader_points.points_reader(xml_file)
+    layers = reader_points.points_reader(filename)
 
     assert len(layers) == 2
 
@@ -31,3 +43,7 @@ def test_reader_xml():
         assert isinstance(layer[0], np.ndarray)
         assert isinstance(layer[1], dict)
         assert isinstance(layer[2], str)
+
+
+def test_reader_no_match():
+    assert reader_points.cellfinder_read_points(broken_xml) is None

--- a/tests/tests/test_integration/test_cellfinder_writer.py
+++ b/tests/tests/test_integration/test_cellfinder_writer.py
@@ -4,7 +4,7 @@ import numpy as np
 from brainglobe_utils.cells.cells import Cell
 from brainglobe_utils.IO.cells import get_cells
 
-from brainglobe_napari_io.cellfinder import reader_xml, writer_xml
+from brainglobe_napari_io.cellfinder import reader_points, writer_points
 
 xml_dir = pathlib.Path(__file__).parent.parent.parent / "data" / "xml"
 
@@ -12,14 +12,14 @@ xml_dir = pathlib.Path(__file__).parent.parent.parent / "data" / "xml"
 def test_xml_roundrip(tmp_path):
     # Check that a read in XML file can also be written back out
     validate_xml_file = xml_dir / "cell_classification.xml"
-    layers = reader_xml.xml_reader(validate_xml_file)
+    layers = reader_points.points_reader(validate_xml_file)
     assert len(layers) == 2
 
     test_xml_path = str(tmp_path / "points.xml")
-    paths = writer_xml.write_multiple_points_to_xml(test_xml_path, layers)
+    paths = writer_points.write_multiple_points(test_xml_path, layers)
     assert len(paths) == 1
     assert isinstance(paths[0], str)
-    assert reader_xml.is_cellfinder_xml(paths[0])
+    assert reader_points.is_cellfinder_xml(paths[0])
 
     cells_validate = get_cells(str(validate_xml_file))
     cells_test = get_cells(test_xml_path)
@@ -44,7 +44,7 @@ def test_xml_write_no_metadata(tmp_path):
         },
         "points",
     )
-    writer_xml.write_multiple_points_to_xml(xml_path, [points])
+    writer_points.write_multiple_points(xml_path, [points])
     cells = get_cells(xml_path)
     assert len(cells) == 10
     assert cells[0].type == Cell.UNKNOWN
@@ -65,4 +65,4 @@ def test_xml_write_no_points(tmp_path):
         },
         "points",
     )
-    assert writer_xml.write_multiple_points_to_xml(xml_path, [points]) == []
+    assert writer_points.write_multiple_points(xml_path, [points]) == []


### PR DESCRIPTION
## Description

This goes along with and depends on https://github.com/brainglobe/brainglobe-utils/pull/131.

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

https://github.com/brainglobe/brainglobe-utils/pull/131 adds support for yaml files as well as associated metadata in `Cell`. This adds similar support in Napari.

**What does this PR do?**

1. This adds YAML files as a file type brainglobe can read/write, like XML.
2. Napari has the `features` property of the Points layer that can be used to associate arbitrary metadata with a point. We use that now to have napari track the Cell metadata along with the points so when it exports points to yaml, the metadata is included as expected.
3. I removed pandas as a dependency. It was barely used, and used for something that can just as easily be done in bare Python. Not sure if these dataframe related stuff in brainglobe-utils is needed only here, in which case perhaps those functions can be pruned.
4. I'm using the `is_brainglobe_xml` and `is_brainglobe_yaml` from the other PR. That scans the file for a given tag/key and returns True if it finds it. Which is much faster than fully parsing the file. The downside is if the key happens to be in the file, but it's not valid xml/yaml we'll still claim it's a brainglobe file. I expect that's not likely, and the user would still get a clear error when it tries to load such a file. So the speedup is probably worth it.

## References

https://github.com/brainglobe/brainglobe-utils/pull/131.

## How has this PR been tested?

Locally and manually with a yaml file.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

No.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
