### PR TITLE
Update brainglobe-utils dependency version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 dependencies = [
     "brainglobe-atlasapi >=2.0.1",
     "brainglobe-space >=1.0.0",
-    "brainglobe-utils >=0.4.2",
+    "brainglobe-utils >=0.9.0",
     "napari>=0.6.1",
     "tifffile>=2020.8.13",
     "numpy",


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**

Following https://github.com/brainglobe/brainglobe-napari-io/pull/102, this package depends on newer `brainglobe-utils` functionality, which was released as part of https://github.com/brainglobe/brainglobe-utils/releases/tag/v0.9.0 (PR 131 in `brainglobe-utils`) 

**What does this PR do?**

Ensures a recent enough version of `brainglobe-utils` is installed. We should make a release after this is merged.
