### PR TITLE
Remove specific backend specification in dev optional dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dev = [
     "pre-commit",
     "ruff",
     "setuptools_scm",
-    "pyqt5"
+    "napari[all]"
 ]
 
 


### PR DESCRIPTION
Removes `pyqt5` from the dev optional dependencies to instead rely on `napari[all]` to supply the default backend.